### PR TITLE
replace wasm-timer to std

### DIFF
--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -59,7 +59,7 @@ web-sys = { version = "0.3", features=["console", "Attr", "CanvasRenderingContex
     "EventTarget", "HtmlCanvasElement", "HtmlElement", "HtmlInputElement", "Node", "Text", "Window", "KeyboardEvent",
     "MouseEvent"] }
 wasm-bindgen = "0.2"
-wasm-timer = "0.1.0"
+web-time = "1.1.0"
 rand = { version = "0.8", default-features = false }
 console_error_panic_hook = "0.1.6"
 winit = { version = "0.30" }

--- a/bracket-terminal/src/hal/wasm/mainloop.rs
+++ b/bracket-terminal/src/hal/wasm/mainloop.rs
@@ -7,6 +7,7 @@ use glow::HasContext;
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasm_bindgen::JsCast;
+use web_time::Instant;
 
 fn window() -> web_sys::Window {
     web_sys::window().expect("no global `window` exists")
@@ -36,7 +37,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> BResult<
         }
     }
 
-    let now = wasm_timer::Instant::now();
+    let now = Instant::now();
     let mut prev_seconds = now.elapsed().as_secs();
     let mut prev_ms = now.elapsed().as_millis();
     let mut frames = 0;
@@ -86,7 +87,7 @@ fn tock<GS: GameState>(
     frames: &mut i32,
     prev_seconds: &mut u64,
     prev_ms: &mut u128,
-    now: &wasm_timer::Instant,
+    now: &Instant,
 ) {
     // Check that the console backings match our actual consoles
     check_console_backing();


### PR DESCRIPTION
Close #13 

wasm-timer는 현재 시점 기준 7년전이 마지막 업데이트입니다.
그래서 해당 구현을 대체하고자 web-time을 활용하였습니다.

이슈에서는 tokio-timer라고 하였으나, 현재 레포에서는 tokio가 존재하지 않는 것으로 보입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated frame timing mechanism in the WASM main loop to use the standard library's timing utilities instead of an external dependency.
  * Removed one external dependency from the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->