### PR TITLE
Add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a reproducible problem in bracket-lib
+title: "[Bug] "
+labels: bug
+---
+
+## Bug description
+
+Clearly and concisely describe the bug.
+
+## Steps to reproduce
+
+1. Go to `...`
+2. Run `...`
+3. Observe `...`
+
+## Expected behavior
+
+Describe what you expected to happen.
+
+## Actual behavior
+
+Describe what actually happened.
+
+## Environment
+
+- OS:
+- Terminal:
+- bracket-lib version/commit:
+
+## Logs or screenshots
+
+Paste relevant logs, error output, or screenshots.

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea or enhancement for bracket-lib
+title: "[Feature] "
+labels: enhancement
+---
+
+## Summary
+
+Briefly describe the feature you want.
+
+## Problem to solve
+
+What problem does this feature solve?  
+Who is affected?
+
+## Proposed solution
+
+Describe your preferred solution in detail.
+
+## Alternatives considered
+
+List any alternative approaches you considered.
+
+## Additional context
+
+Add examples, screenshots, links, or related issues if applicable.


### PR DESCRIPTION
## Why
Issue reporting was not standardized in this repository. This adds dedicated templates so contributors can submit clearer and more consistent bug reports and feature requests.

## What changed
- Added `.github/ISSUE_TEMPLATE/BUG_REPORT.md` with front matter and sections for reproduction steps, expected vs actual behavior, environment, and logs.
- Added `.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md` with front matter and sections for summary, problem, proposed solution, alternatives, and context.
- Kept template structure aligned with the reference format from `utilForever/focustime` and adapted wording for `ossca-2026-rltk`.

## Notes
This PR only adds documentation templates under `.github/ISSUE_TEMPLATE` and does not change Rust code.

Fixes: #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub issue templates for bug reports and feature requests to standardize issue submissions with structured sections for relevant details and context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->