### PR TITLE
Add CONTRIBUTING.md contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing to ossca-2026-rltk
+
+Thanks for contributing to **ossca-2026-rltk**. This guide explains the expected workflow and quality bar for pull requests.
+
+## Getting Started
+
+1. Install the stable Rust toolchain.
+2. Clone the repository and open it in your terminal.
+3. Run the core checks before opening a PR:
+
+```sh
+cargo check --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions
+cargo test --all
+```
+
+Optional local build:
+
+```sh
+cargo build
+```
+
+Optional dependency checks:
+
+```sh
+cargo +nightly udeps --all-targets
+cargo audit
+```
+
+## Architecture
+
+`ossca-2026-rltk` is a Rust workspace centered on a stable facade crate (`bracket-lib`) with focused `bracket-*` crates and a compatibility facade (`rltk`).
+
+- `bracket-lib` and `rltk` are the primary high-level entry points for users.
+- Runtime and rendering backends are in `bracket-terminal` (feature-gated by backend).
+- Algorithms and shared abstractions live in `bracket-pathfinding` and `bracket-algorithm-traits`.
+- Supporting domains are split into focused crates such as `bracket-color`, `bracket-geometry`, `bracket-random`, and `bracket-noise`.
+
+See [ARCHITECTURE.md](./ARCHITECTURE.md) for the full crate map, runtime flow, and extension boundaries.
+
+## Code Style
+
+- Run `cargo fmt --all` before committing.
+- Treat Clippy warnings as errors:
+
+```sh
+cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions
+```
+
+- Keep crate responsibilities focused and avoid leaking implementation-only internals across crate boundaries.
+- Prefer feature-gated backend integrations instead of runtime branching for backend selection.
+- Use additive public API changes; avoid breaking downstream users unnecessarily.
+- Keep changes focused and avoid unrelated refactors.
+- Add or update tests when behavior changes.
+
+## Pull Requests
+
+- Open pull requests against the `main` branch.
+- Keep each PR focused on one meaningful change.
+- Link the related issue in the PR description (for example: `Closes #123`).
+- Ensure CI-equivalent checks pass locally:
+
+```sh
+cargo check --all
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions
+cargo test --all
+```
+
+- Update user-facing docs when behavior or usage changes.
+- Do not include sensitive values or credentials.
+
+## Releasing
+
+The project follows Conventional Commit-style release commit conventions:
+
+- Release commit format: `feat: vX.Y.Z — short summary`
+- Hotfix format: `fix: description` (no version in the message)
+
+Before preparing a release change, make sure all CI jobs pass for the release-related updates.
+
+## Dependencies
+
+Dependency and ecosystem checks are part of contributor quality expectations:
+
+- Prefer minimal, well-maintained crates.
+- Document new dependencies or configuration changes in the PR.
+- When dependencies change, run:
+
+```sh
+cargo +nightly udeps --all-targets
+cargo audit
+```

--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 
 ## Documentation
 
+- [CONTRIBUTING.md](./CONTRIBUTING.md): Contributor workflow, quality checks, and PR expectations
 - [AGENTS.md](./AGENTS.md): Repository-specific guide for AI coding agents
 - [ARCHITECTURE.md](./ARCHITECTURE.md): Project architecture and crate-level design overview


### PR DESCRIPTION
## What

Add a new root `CONTRIBUTING.md` contributor guide with the requested sections: Getting Started, Architecture, Code Style, Pull Requests, Releasing, and Dependencies. Also add a `CONTRIBUTING.md` entry under the README documentation links.

## Why

Issue #51 requests a dedicated contributor guide so contributors can quickly find onboarding steps, quality expectations, and PR workflow guidance in one place.

Closes #51.

## Checklist

### Required

- [ ] `cargo check --all` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [ ] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [ ] Behavior related to this change was verified locally (if applicable) (N/A, docs-only change)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable) (N/A, docs-only change)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable) (N/A, docs-only change)
- [ ] I added or updated tests for changed behavior (if applicable) (N/A, docs-only change)

### Configuration & Docs

- [x] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable) (N/A)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed) (N/A)
- [ ] Breaking behavior changes are clearly described in this PR (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive contributing guide with workflow standards and quality check requirements.
  * Updated README with link to contributor documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->