### PR TITLE
Replace crate wasm-timer to web-time

### DIFF
--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -59,10 +59,10 @@ web-sys = { version = "0.3", features=["console", "Attr", "CanvasRenderingContex
     "EventTarget", "HtmlCanvasElement", "HtmlElement", "HtmlInputElement", "Node", "Text", "Window", "KeyboardEvent",
     "MouseEvent"] }
 wasm-bindgen = "0.2"
-wasm-timer = "0.1.0"
 rand = { version = "0.8", default-features = false }
 console_error_panic_hook = "0.1.6"
 winit = { version = "0.30" }
+web-time = "1.1.0"
 
 [[bench]]
 name = "batching_benchmark"

--- a/bracket-terminal/src/hal/wasm/mainloop.rs
+++ b/bracket-terminal/src/hal/wasm/mainloop.rs
@@ -36,7 +36,7 @@ pub fn main_loop<GS: GameState>(mut bterm: BTerm, mut gamestate: GS) -> BResult<
         }
     }
 
-    let now = wasm_timer::Instant::now();
+    let now = web_time::Instant::now();
     let mut prev_seconds = now.elapsed().as_secs();
     let mut prev_ms = now.elapsed().as_millis();
     let mut frames = 0;
@@ -86,7 +86,7 @@ fn tock<GS: GameState>(
     frames: &mut i32,
     prev_seconds: &mut u64,
     prev_ms: &mut u128,
-    now: &wasm_timer::Instant,
+    now: &web_time::Instant,
 ) {
     // Check that the console backings match our actual consoles
     check_console_backing();


### PR DESCRIPTION
## What

- Change [wasm-timer](https://github.com/tomaka/wasm-timer) to [web-time](https://github.com/daxpedda/web-time)
- At the same time, tokio-timer and tokio-executor were also removed from the dependency tree

Close #10.
Close #12. 
Close #13.

## Why

- wasm-timer is no longer maintained
- tokio-timer and tokio-executor are also no longer maintained

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [ ] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [ ] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated WASM build dependencies to replace the timing implementation for improved web platform compatibility.
  * Expect more reliable frame timing and smoother behavior in web/WASM deployments, reducing timing-related glitches during rendering and input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->