### PR TITLE
Add macOS check matrix

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,8 +13,11 @@ permissions:
 
 jobs:
   check:
-    name: ✅ Check
-    runs-on: ubuntu-latest
+    name: ✅ Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v6


### PR DESCRIPTION
## What

Add `macos-latest` to the GitHub Actions `check` job OS matrix.

## Why

The CI check job currently runs only on Ubuntu. Running `cargo check --all` on both Ubuntu and macOS helps catch platform-specific build issues earlier.

## Scope Note

I suggest run both build/check and test jobs across operating systems. This PR keeps the scope limited to the macOS check coverage originally requested. If expanding test coverage across operating systems is desirable, I can follow up with a separate issue for that work.

Closes #28.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [x] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to extend testing coverage across multiple operating systems (Ubuntu and macOS).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->