### PR TITLE
Update criterion from 0.4 to 0.8.2

### DIFF
--- a/bracket-pathfinding/Cargo.toml
+++ b/bracket-pathfinding/Cargo.toml
@@ -28,7 +28,7 @@ smallvec = "~1"
 crossterm = "~0.25"
 bracket-random = { path = "../bracket-random", version = "0.8" }
 bracket-color = { path = "../bracket-color", version = "~0.8", features = [ "palette" ] }
-criterion = "~0.4"
+criterion = "~0.8.2"
 
 [[bench]]
 name = "fov_benchmark"

--- a/bracket-pathfinding/benches/astar_benchmark.rs
+++ b/bracket-pathfinding/benches/astar_benchmark.rs
@@ -3,7 +3,8 @@
 // Benchmark field of view calculations,
 // most of the code copied from ex04-fov.rs
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
 use bracket_pathfinding::prelude::*;
 

--- a/bracket-pathfinding/benches/fov_benchmark.rs
+++ b/bracket-pathfinding/benches/fov_benchmark.rs
@@ -3,7 +3,8 @@
 // Benchmark field of view calculations,
 // most of the code copied from ex04-fov.rs
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
 use bracket_pathfinding::prelude::*;
 

--- a/bracket-random/Cargo.toml
+++ b/bracket-random/Cargo.toml
@@ -32,7 +32,7 @@ js-sys = "0.3.48"
 wasm-bindgen = "0.2"
 
 [dev-dependencies]
-criterion = "~0.4"
+criterion = "~0.8.2"
 serde_json = "~1.0"
 
 [[bench]]

--- a/bracket-random/benches/dice.rs
+++ b/bracket-random/benches/dice.rs
@@ -2,7 +2,8 @@
 
 // Benchmark field of geometry calculations
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
+use std::hint::black_box;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     use bracket_random::prelude::*;

--- a/bracket-terminal/Cargo.toml
+++ b/bracket-terminal/Cargo.toml
@@ -52,7 +52,7 @@ webgpu = [ "wgpu", "pollster", "image", "bytemuck", "png" ]
 bracket-random = { path = "../bracket-random", version = "~0.8" }
 bracket-pathfinding = { path = "../bracket-pathfinding", version = "~0.8" }
 bracket-noise = { path = "../bracket-noise", version = "~0.8" }
-criterion = "~0.4"
+criterion = "~0.8.2"
 
 [target.wasm32-unknown-unknown.dependencies]
 web-sys = { version = "0.3", features=["console", "Attr", "CanvasRenderingContext2d", "Document", "Element", "Event",


### PR DESCRIPTION
## What

- I upgraded the version of [criterion](https://github.com/criterion-rs/criterion.rs) from 0.4 to 0.8.2.

Close #8 

## Why

- I am not directly using the [atty](https://github.com/softprops/atty) library, but rather the current criterion is using it.

## Checklist

### Required

- [ ] `cargo check --all` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [ ] `cargo test --all` passes
- [ ] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [ ] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [ ] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [ ] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated benchmark tooling dependencies to latest version across all crates for improved performance testing infrastructure.
  * Adjusted internal imports to align with updated benchmarking library compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->