### PR TITLE
Add wasm32-unknown-unknown build workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,3 +82,31 @@ jobs:
         uses: actions/checkout@v6
       - name: Audit Rust dependencies
         uses: actions-rust-lang/audit@v1
+
+  wasm_build:
+    name: 🕸️ WASM Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+      - name: Install stable toolchain with wasm32 target
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: wasm32
+      # Scoped to `-p bracket-terminal` deliberately. Do NOT widen to `--workspace`:
+      # `bracket-bevy` depends on Bevy 0.9 with the `x11` feature
+      # (bracket-bevy/Cargo.toml lines 18-29), which has no wasm32 build today.
+      # Only `bracket-random` and `bracket-terminal` carry `#[cfg(target_arch = "wasm32")]`
+      # divergent code paths; `bracket-terminal`'s examples transitively exercise both.
+      # Two examples are built (not one) so an upstream rename/deletion of either
+      # `dwarfmap` or `hello_terminal` still leaves wasm coverage in place.
+      # TODO: once Bevy block is cfg-gated for non-wasm32 (follow-up issue #N),
+      # collapse to `cargo build --workspace --target wasm32-unknown-unknown`.
+      - name: Build dwarfmap example for wasm32
+        run: cargo build -p bracket-terminal --example dwarfmap --target wasm32-unknown-unknown
+      - name: Build hello_terminal example for wasm32
+        run: cargo build -p bracket-terminal --example hello_terminal --target wasm32-unknown-unknown


### PR DESCRIPTION
## What

Add a new `wasm_build` CI job that builds the `bracket-terminal` `dwarfmap` and `hello_terminal` examples for `wasm32-unknown-unknown` on every PR.

## Why

Issue #29 asked for WebAssembly target CI coverage. Previously, no CI job compiled code behind `#[cfg(target_arch = "wasm32")]`, so wasm-only regressions could pass unnoticed.

Closes #29.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [x] Behavior related to this change was verified locally (same commands as the new job): `cargo build -p bracket-terminal --example dwarfmap --target wasm32-unknown-unknown` and `cargo build -p bracket-terminal --example hello_terminal --target wasm32-unknown-unknown`
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable) (N/A: workflow-only change)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable) (N/A: workflow-only change)
- [ ] I added or updated tests for changed behavior (if applicable) (N/A: workflow-only change)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable) (N/A: workflow-only change)
- [x] New dependencies/configuration are documented (if applicable) (added inline YAML comments explaining the `-p bracket-terminal` scope and why both examples are built)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed) (no additional risk; only standard third-party actions used: `actions/checkout@v6`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`)
- [x] Breaking behavior changes are clearly described in this PR (none)

## Stacking

This PR depends on prerequisite PR #81 (`fix/bracket-lib-wasm32-build`).

- If #81 merges first, this PR diff narrows to a single CI YAML change.
- The new `wasm_build` job goes green only after #81, but this workflow change remains independently reviewable.

## Reviewer Notes

- The job is intentionally scoped to `-p bracket-terminal`. Expanding to `--workspace` currently fails due to `bracket-bevy` (Bevy 0.9 + `x11` feature) on this target; comments in YAML call this out.
- Both examples are built (not just one) so wasm coverage remains even if one upstream example is renamed/removed.
- Making `wasm_build` a required status check needs repository admin settings and is intentionally out of scope for this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated WebAssembly builds for example projects in the continuous integration pipeline.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/roguekit/pull/82)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->