### PR TITLE
Cover RGB and RGBA color APIs

### DIFF
--- a/bracket-color/src/rgb.rs
+++ b/bracket-color/src/rgb.rs
@@ -486,6 +486,20 @@ mod tests {
     }
 
     #[rstest]
+    #[case(RGB::from_f32(-1.0, 0.5, 2.0), 0.0, 0.5, 1.0)]
+    #[case(RGB::from_u8(255, 128, 0), 1.0, 128.0 / 255.0, 0.0)]
+    #[case(RGB::from((64, 128, 255)), 64.0 / 255.0, 128.0 / 255.0, 1.0)]
+    #[case(RGB::from(RGBA::from_f32(0.25, 0.5, 0.75, 0.125)), 0.25, 0.5, 0.75)]
+    fn construction_and_conversion_set_expected_components(
+        #[case] rgb: RGB,
+        #[case] r: f32,
+        #[case] g: f32,
+        #[case] b: f32,
+    ) {
+        assert_rgb_eq(rgb, r, g, b);
+    }
+
+    #[rstest]
     #[case(RGB::from_f32(1.0, 0.0, 0.0), 0.0, 1.0, 1.0)]
     #[case(RGB::from_f32(0.0, 1.0, 0.0), 120.0 / 360.0, 1.0, 1.0)]
     #[case(RGB::from_f32(0.0, 0.0, 1.0), 240.0 / 360.0, 1.0, 1.0)]
@@ -514,14 +528,40 @@ mod tests {
         assert_hsv_eq(hsv, 60.0 / 360.0, 1.0, 128.0 / 255.0);
     }
 
-    #[test]
-    fn convert_rgb_to_rgba_preserves_rgb_and_sets_alpha() {
-        let rgba = RGB::from_f32(1.0, 0.0, 0.0).to_rgba(0.5);
+    #[rstest]
+    #[case(0.0)]
+    #[case(0.5)]
+    #[case(1.0)]
+    fn convert_rgb_to_rgba_preserves_rgb_and_sets_alpha(#[case] alpha: f32) {
+        let rgba = RGB::from_f32(1.0, 0.0, 0.0).to_rgba(alpha);
 
-        assert_approx_eq(rgba.r, 1.0);
-        assert_approx_eq(rgba.g, 0.0);
-        assert_approx_eq(rgba.b, 0.0);
-        assert_approx_eq(rgba.a, 0.5);
+        assert_rgba_eq(rgba, 1.0, 0.0, 0.0, alpha);
+    }
+
+    #[test]
+    fn xp_color_round_trip_preserves_bytes() {
+        let xp = XpColor::new(17, 128, 255);
+        let rgb = RGB::from_xp(xp);
+        assert_rgb_eq(rgb, 17.0 / 255.0, 128.0 / 255.0, 1.0);
+
+        let converted = rgb.to_xp();
+        assert_eq!(converted.r, 17);
+        assert_eq!(converted.g, 128);
+        assert_eq!(converted.b, 255);
+    }
+
+    #[test]
+    fn to_xp_clamps_out_of_range_components() {
+        let rgb = RGB {
+            r: -0.5,
+            g: 0.5,
+            b: 1.5,
+        };
+        let xp = rgb.to_xp();
+
+        assert_eq!(xp.r, 0);
+        assert_eq!(xp.g, 127);
+        assert_eq!(xp.b, 255);
     }
 
     #[rstest]
@@ -560,9 +600,7 @@ mod tests {
     fn test_blue_named() {
         let rgb = RGB::named(BLUE);
 
-        assert_approx_eq(rgb.r, 0.0);
-        assert_approx_eq(rgb.g, 0.0);
-        assert_approx_eq(rgb.b, 1.0);
+        assert_rgb_eq(rgb, 0.0, 0.0, 1.0);
     }
 
     #[test]

--- a/bracket-color/src/rgb.rs
+++ b/bracket-color/src/rgb.rs
@@ -485,18 +485,28 @@ mod tests {
         assert_rgb_eq(RGB::new(), 0.0, 0.0, 0.0);
     }
 
-    #[rstest]
-    #[case(RGB::from_f32(-1.0, 0.5, 2.0), 0.0, 0.5, 1.0)]
-    #[case(RGB::from_u8(255, 128, 0), 1.0, 128.0 / 255.0, 0.0)]
-    #[case(RGB::from((64, 128, 255)), 64.0 / 255.0, 128.0 / 255.0, 1.0)]
-    #[case(RGB::from(RGBA::from_f32(0.25, 0.5, 0.75, 0.125)), 0.25, 0.5, 0.75)]
-    fn construction_and_conversion_set_expected_components(
-        #[case] rgb: RGB,
-        #[case] r: f32,
-        #[case] g: f32,
-        #[case] b: f32,
-    ) {
-        assert_rgb_eq(rgb, r, g, b);
+    #[test]
+    fn from_f32_clamps_components() {
+        let rgb = RGB::from_f32(-1.0, 0.5, 2.0);
+        assert_rgb_eq(rgb, 0.0, 0.5, 1.0);
+    }
+
+    #[test]
+    fn from_u8_converts_components() {
+        let rgb = RGB::from_u8(255, 128, 0);
+        assert_rgb_eq(rgb, 1.0, 128.0 / 255.0, 0.0);
+    }
+
+    #[test]
+    fn tuple_conversion_uses_u8_components() {
+        let rgb = RGB::from((64, 128, 255));
+        assert_rgb_eq(rgb, 64.0 / 255.0, 128.0 / 255.0, 1.0);
+    }
+
+    #[test]
+    fn rgba_conversion_drops_alpha() {
+        let rgb = RGB::from(RGBA::from_f32(0.25, 0.5, 0.75, 0.125));
+        assert_rgb_eq(rgb, 0.25, 0.5, 0.75);
     }
 
     #[rstest]

--- a/bracket-color/src/rgb.rs
+++ b/bracket-color/src/rgb.rs
@@ -509,6 +509,12 @@ mod tests {
         assert_rgb_eq(rgb, 0.25, 0.5, 0.75);
     }
 
+    #[test]
+    fn hsv_conversion_delegates_to_hsv_to_rgb() {
+        let rgb = RGB::from(HSV::from_f32(120.0 / 360.0, 1.0, 1.0));
+        assert_rgb_eq(rgb, 0.0, 1.0, 0.0);
+    }
+
     #[rstest]
     #[case(RGB::from_f32(0.25, 0.5, 0.75) + 0.125, 0.375, 0.625, 0.875)]
     #[case(
@@ -569,6 +575,14 @@ mod tests {
         assert_hsv_eq(hsv, 60.0 / 360.0, 1.0, 128.0 / 255.0);
     }
 
+    #[test]
+    fn convert_magenta_to_hsv_wraps_red_hue() {
+        let rgb = RGB::from_f32(1.0, 0.0, 0.5);
+        let hsv = rgb.to_hsv();
+
+        assert_hsv_eq(hsv, 330.0 / 360.0, 1.0, 1.0);
+    }
+
     #[rstest]
     #[case(0.0)]
     #[case(0.5)]
@@ -623,18 +637,46 @@ mod tests {
 
     #[rstest]
     #[case("")]
+    #[case("#")]
+    #[case("#F")]
+    #[case("#FF")]
     #[case("#FFF")]
     #[case("#FFFF")]
+    #[case("#FFFFF")]
     #[case("#FFFFFF00")]
     fn parse_hex_rejects_invalid_length(#[case] hex: &str) {
         let err = RGB::from_hex(hex).unwrap_err();
         assert_eq!(err, HtmlColorConversionError::InvalidStringLength);
     }
 
-    #[test]
-    fn parse_hex_rejects_invalid_character() {
-        let err = RGB::from_hex("#GG0000").unwrap_err();
+    #[rstest]
+    #[case("#GG0000")]
+    #[case("#FG0000")]
+    #[case("#FFG000")]
+    #[case("#FF0G00")]
+    #[case("#FF00G0")]
+    #[case("#FF000G")]
+    fn parse_hex_rejects_invalid_character(#[case] hex: &str) {
+        let err = RGB::from_hex(hex).unwrap_err();
         assert_eq!(err, HtmlColorConversionError::InvalidCharacter);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn bevy_color_conversion_preserves_rgb_channels() {
+        let rgb = RGB::from(bevy::prelude::Color::srgb(0.25, 0.5, 0.75));
+        assert_rgb_eq(rgb, 0.25, 0.5, 0.75);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn rgb_conversion_to_bevy_color_preserves_rgb_channels() {
+        let color = bevy::prelude::Color::from(RGB::from_f32(0.25, 0.5, 0.75));
+        let srgba = color.to_srgba();
+
+        assert_approx_eq(srgba.red, 0.25);
+        assert_approx_eq(srgba.green, 0.5);
+        assert_approx_eq(srgba.blue, 0.75);
     }
 
     #[test]

--- a/bracket-color/src/rgb.rs
+++ b/bracket-color/src/rgb.rs
@@ -500,6 +500,37 @@ mod tests {
     }
 
     #[rstest]
+    #[case(RGB::from_f32(0.25, 0.5, 0.75) + 0.125, 0.375, 0.625, 0.875)]
+    #[case(
+        RGB::from_f32(0.25, 0.5, 0.75) + RGB::from_f32(0.125, 0.25, 0.125),
+        0.375,
+        0.75,
+        0.875
+    )]
+    #[case(RGB::from_f32(0.25, 0.5, 0.75) - 0.125, 0.125, 0.375, 0.625)]
+    #[case(
+        RGB::from_f32(0.25, 0.5, 0.75) - RGB::from_f32(0.125, 0.25, 0.125),
+        0.125,
+        0.25,
+        0.625
+    )]
+    #[case(RGB::from_f32(0.25, 0.5, 0.75) * 0.5, 0.125, 0.25, 0.375)]
+    #[case(
+        RGB::from_f32(0.25, 0.5, 0.75) * RGB::from_f32(0.125, 0.25, 0.125),
+        0.03125,
+        0.125,
+        0.09375
+    )]
+    fn arithmetic_operators_apply_component_wise(
+        #[case] rgb: RGB,
+        #[case] r: f32,
+        #[case] g: f32,
+        #[case] b: f32,
+    ) {
+        assert_rgb_eq(rgb, r, g, b);
+    }
+
+    #[rstest]
     #[case(RGB::from_f32(1.0, 0.0, 0.0), 0.0, 1.0, 1.0)]
     #[case(RGB::from_f32(0.0, 1.0, 0.0), 120.0 / 360.0, 1.0, 1.0)]
     #[case(RGB::from_f32(0.0, 0.0, 1.0), 240.0 / 360.0, 1.0, 1.0)]
@@ -601,6 +632,34 @@ mod tests {
         let rgb = RGB::named(BLUE);
 
         assert_rgb_eq(rgb, 0.0, 0.0, 1.0);
+    }
+
+    #[test]
+    fn to_greyscale_uses_luminance_weights() {
+        let grey = RGB::from_f32(1.0, 0.0, 0.0).to_greyscale();
+        assert_rgb_eq(grey, 0.2126, 0.2126, 0.2126);
+    }
+
+    #[test]
+    fn desaturate_keeps_value_and_removes_saturation() {
+        let desaturated = RGB::from_f32(1.0, 0.0, 0.0).desaturate();
+        assert_rgb_eq(desaturated, 1.0, 1.0, 1.0);
+    }
+
+    #[rstest]
+    #[case(0.0, 0.0, 0.0, 0.0)]
+    #[case(0.5, 0.5, 0.5, 0.5)]
+    #[case(1.0, 1.0, 1.0, 1.0)]
+    fn lerp_interpolates_between_colors(
+        #[case] percent: f32,
+        #[case] r: f32,
+        #[case] g: f32,
+        #[case] b: f32,
+    ) {
+        let black = RGB::named(BLACK);
+        let white = RGB::named(WHITE);
+
+        assert_rgb_eq(black.lerp(white, percent), r, g, b);
     }
 
     #[test]

--- a/bracket-color/src/rgba.rs
+++ b/bracket-color/src/rgba.rs
@@ -527,6 +527,41 @@ mod tests {
     }
 
     #[rstest]
+    #[case(RGBA::from_f32(0.25, 0.5, 0.75, 0.5) + 0.125, 0.375, 0.625, 0.875, 0.625)]
+    #[case(
+        RGBA::from_f32(0.25, 0.5, 0.75, 0.5) + RGBA::from_f32(0.125, 0.25, 0.125, 0.25),
+        0.375,
+        0.75,
+        0.875,
+        0.75
+    )]
+    #[case(RGBA::from_f32(0.25, 0.5, 0.75, 0.5) - 0.125, 0.125, 0.375, 0.625, 0.375)]
+    #[case(
+        RGBA::from_f32(0.25, 0.5, 0.75, 0.5) - RGBA::from_f32(0.125, 0.25, 0.125, 0.25),
+        0.125,
+        0.25,
+        0.625,
+        0.25
+    )]
+    #[case(RGBA::from_f32(0.25, 0.5, 0.75, 0.5) * 0.5, 0.125, 0.25, 0.375, 0.25)]
+    #[case(
+        RGBA::from_f32(0.25, 0.5, 0.75, 0.5) * RGBA::from_f32(0.125, 0.25, 0.125, 0.25),
+        0.03125,
+        0.125,
+        0.09375,
+        0.125
+    )]
+    fn arithmetic_operators_apply_component_wise(
+        #[case] rgba: RGBA,
+        #[case] r: f32,
+        #[case] g: f32,
+        #[case] b: f32,
+        #[case] a: f32,
+    ) {
+        assert_rgba_eq(rgba, r, g, b, a);
+    }
+
+    #[rstest]
     #[case("#FF0000FF", 1.0, 0.0, 0.0, 1.0)]
     #[case("#00FF00FF", 0.0, 1.0, 0.0, 1.0)]
     #[case("#0000FFFF", 0.0, 0.0, 1.0, 1.0)]
@@ -602,6 +637,8 @@ mod tests {
         let white = RGBA::named(WHITE);
         assert!(black.lerp(white, 0.0) == black);
         assert!(black.lerp(white, 1.0) == white);
+
+        assert_rgba_eq(black.lerp(white, 0.5), 0.5, 0.5, 0.5, 1.0);
     }
 
     #[test]
@@ -613,10 +650,7 @@ mod tests {
         let l0 = black.lerp_alpha(white, 0.0);
         let l1 = black.lerp_alpha(white, 1.0);
 
-        assert!(l0.a < f32::EPSILON);
-        assert!((l1.a - 1.0).abs() < f32::EPSILON);
-
-        assert!(l0.to_rgb() == RGB::named(BLACK));
-        assert!(l1.to_rgb() == RGB::named(BLACK));
+        assert_rgba_eq(l0, 0.0, 0.0, 0.0, 0.0);
+        assert_rgba_eq(l1, 0.0, 0.0, 0.0, 1.0);
     }
 }

--- a/bracket-color/src/rgba.rs
+++ b/bracket-color/src/rgba.rs
@@ -526,6 +526,12 @@ mod tests {
         assert_rgba_eq(rgba, r, g, b, a);
     }
 
+    #[test]
+    fn hsv_conversion_uses_opaque_alpha() {
+        let rgba = RGBA::from(HSV::from_f32(240.0 / 360.0, 1.0, 1.0));
+        assert_rgba_eq(rgba, 0.0, 0.0, 1.0, 1.0);
+    }
+
     #[rstest]
     #[case(RGBA::from_f32(0.25, 0.5, 0.75, 0.5) + 0.125, 0.375, 0.625, 0.875, 0.625)]
     #[case(
@@ -585,18 +591,58 @@ mod tests {
 
     #[rstest]
     #[case("")]
+    #[case("#")]
+    #[case("#F")]
+    #[case("#FF")]
     #[case("#FFF")]
+    #[case("#FFFF")]
+    #[case("#FFFFF")]
     #[case("#FFFFFF")]
+    #[case("#FFFFFFF")]
     #[case("#FFFFFFFF00")]
     fn parse_hex_rejects_invalid_length(#[case] hex: &str) {
         let err = RGBA::from_hex(hex).unwrap_err();
         assert_eq!(err, HtmlColorConversionError::InvalidStringLength);
     }
 
-    #[test]
-    fn parse_hex_rejects_invalid_character() {
-        let err = RGBA::from_hex("#GG0000FF").unwrap_err();
+    #[rstest]
+    #[case("#GG0000FF")]
+    #[case("#FG0000FF")]
+    #[case("#FFG000FF")]
+    #[case("#FF0G00FF")]
+    #[case("#FF00G0FF")]
+    #[case("#FF000GFF")]
+    #[case("#FF0000GF")]
+    #[case("#FF0000FG")]
+    fn parse_hex_rejects_invalid_character(#[case] hex: &str) {
+        let err = RGBA::from_hex(hex).unwrap_err();
         assert_eq!(err, HtmlColorConversionError::InvalidCharacter);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn as_rgba_f32_returns_components_for_bevy() {
+        let rgba = RGBA::from_f32(0.25, 0.5, 0.75, 0.125);
+        assert_eq!(rgba.as_rgba_f32(), [0.25, 0.5, 0.75, 0.125]);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn bevy_color_conversion_preserves_rgba_channels() {
+        let rgba = RGBA::from(bevy::prelude::Color::srgba(0.25, 0.5, 0.75, 0.125));
+        assert_rgba_eq(rgba, 0.25, 0.5, 0.75, 0.125);
+    }
+
+    #[cfg(feature = "bevy")]
+    #[test]
+    fn rgba_conversion_to_bevy_color_preserves_rgba_channels() {
+        let color = bevy::prelude::Color::from(RGBA::from_f32(0.25, 0.5, 0.75, 0.125));
+        let srgba = color.to_srgba();
+
+        assert_approx_eq(srgba.red, 0.25);
+        assert_approx_eq(srgba.green, 0.5);
+        assert_approx_eq(srgba.blue, 0.75);
+        assert_approx_eq(srgba.alpha, 0.125);
     }
 
     #[test]

--- a/bracket-color/src/rgba.rs
+++ b/bracket-color/src/rgba.rs
@@ -623,7 +623,12 @@ mod tests {
     #[test]
     fn as_rgba_f32_returns_components_for_bevy() {
         let rgba = RGBA::from_f32(0.25, 0.5, 0.75, 0.125);
-        assert_eq!(rgba.as_rgba_f32(), [0.25, 0.5, 0.75, 0.125]);
+        let [r, g, b, a] = rgba.as_rgba_f32();
+
+        assert_approx_eq(r, 0.25);
+        assert_approx_eq(g, 0.5);
+        assert_approx_eq(b, 0.75);
+        assert_approx_eq(a, 0.125);
     }
 
     #[cfg(feature = "bevy")]

--- a/bracket-color/src/rgba.rs
+++ b/bracket-color/src/rgba.rs
@@ -506,6 +506,27 @@ mod tests {
     }
 
     #[rstest]
+    #[case(RGBA::from(RGB::from_f32(0.25, 0.5, 0.75)), 0.25, 0.5, 0.75, 1.0)]
+    #[case(
+        RGBA::from((64, 128, 255, 32)),
+        64.0 / 255.0,
+        128.0 / 255.0,
+        1.0,
+        32.0 / 255.0
+    )]
+    #[case(RGBA::from((64, 128, 255)), 64.0 / 255.0, 128.0 / 255.0, 1.0, 1.0)]
+    #[case(RGBA::from([-1.0, 0.5, 2.0, 0.25]), 0.0, 0.5, 1.0, 0.25)]
+    fn conversions_fill_or_preserve_alpha(
+        #[case] rgba: RGBA,
+        #[case] r: f32,
+        #[case] g: f32,
+        #[case] b: f32,
+        #[case] a: f32,
+    ) {
+        assert_rgba_eq(rgba, r, g, b, a);
+    }
+
+    #[rstest]
     #[case("#FF0000FF", 1.0, 0.0, 0.0, 1.0)]
     #[case("#00FF00FF", 0.0, 1.0, 0.0, 1.0)]
     #[case("#0000FFFF", 0.0, 0.0, 1.0, 1.0)]


### PR DESCRIPTION
## What

Add focused unit tests for RGB and RGBA color APIs, including construction, conversions, hex parsing edge cases, arithmetic, transforms, and Bevy feature conversions.

## Why

RGB/RGBA color APIs lacked direct coverage for several public conversion and parsing paths. These tests document the expected component behavior and bring `rgb.rs` and `rgba.rs` line coverage to 100% when the Bevy feature is enabled.

Closes #89

### Before
<img width="1138" height="51" alt="before rgb test" src="https://github.com/user-attachments/assets/a52e9b14-f233-4fd2-b3eb-37fb486d36c6" />

### After
<img width="609" height="53" alt="after rgb 테스트" src="https://github.com/user-attachments/assets/1934f157-8afe-44b7-8f4d-0a8b32b8621b" />

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [x] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR

## Verification

- `cargo check --all`
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions`
- `cargo test --all`
- `cargo test -p bracket-color --features bevy`
- `cargo llvm-cov -p bracket-color --features bevy --html --open`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for color conversions (RGB, RGBA, HSV) including edge cases and clamping behavior.
  * Improved hex parsing tests with more comprehensive validation scenarios.
  * Enhanced round-trip conversion testing to ensure data integrity across color formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/roguekit/pull/91)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->