### PR TITLE
Fix regression & Improve test coverage related to 'DijkstraMap'

### DIFF
--- a/bracket-pathfinding/src/dijkstra.rs
+++ b/bracket-pathfinding/src/dijkstra.rs
@@ -149,6 +149,7 @@ impl DijkstraMap {
         let mut open_list: VecDeque<(usize, f32)> = VecDeque::with_capacity(mapsize);
 
         for start in starts {
+            dm.map[*start] = f32::min(dm.map[*start], 0.0);
             open_list.push_back((*start, 0.0));
         }
 
@@ -180,6 +181,7 @@ impl DijkstraMap {
         let mut open_list: VecDeque<(usize, f32)> = VecDeque::with_capacity(mapsize);
 
         for start in starts {
+            dm.map[start.0] = f32::min(dm.map[start.0], start.1);
             open_list.push_back(*start);
         }
 
@@ -226,6 +228,7 @@ impl DijkstraMap {
             let mut open_list: VecDeque<(usize, f32)> = VecDeque::with_capacity(mapsize);
 
             for start in l.starts.iter().copied() {
+                l.map[start] = f32::min(l.map[start], 0.0);
                 open_list.push_back((start, 0.0));
             }
 

--- a/bracket-pathfinding/src/dijkstra.rs
+++ b/bracket-pathfinding/src/dijkstra.rs
@@ -338,7 +338,10 @@ impl DijkstraMap {
 mod test {
     use crate::prelude::*;
     use bracket_algorithm_traits::prelude::*;
-    // 1 by 3 stripe of tiles
+    // 1 by 3 stripe of tiles.
+    //
+    // [0] --1--> [1] --2--> [2]
+    // [0] <--1-- [1] <--1-- [2]
     struct MiniMap;
     impl BaseMap for MiniMap {
         fn get_available_exits(&self, idx: usize) -> SmallVec<[(usize, f32); 10]> {
@@ -349,6 +352,60 @@ mod test {
             }
         }
     }
+    #[test]
+    fn test_new() {
+        let map = MiniMap {};
+        let from_zero = DijkstraMap::new(3, 1, &[0], &map, 10.);
+        let from_one = DijkstraMap::new(3, 1, &[1], &map, 10.);
+        let from_both = DijkstraMap::new(3, 1, &[0, 1], &map, 10.);
+
+        assert_eq!(from_zero.map, vec![0., 1., 3.]);
+        assert_eq!(from_one.map, vec![1., 0., 2.]);
+        assert_eq!(from_both.map, vec![0., 0., 2.]);
+    }
+
+    #[test]
+    fn test_new_weighted() {
+        let map = MiniMap {};
+        let from_zero = DijkstraMap::new_weighted(3, 1, &[(0, 1.)], &map, 10.);
+        let from_one = DijkstraMap::new_weighted(3, 1, &[(1, 0.)], &map, 10.);
+        let from_both = DijkstraMap::new_weighted(3, 1, &[(0, 1.), (1, 0.)], &map, 10.);
+
+        assert_eq!(from_zero.map, vec![1., 2., 4.]);
+        assert_eq!(from_one.map, vec![1., 0., 2.]);
+        assert_eq!(from_both.map, vec![1., 0., 2.]);
+    }
+
+    #[test]
+    fn test_new_empty() {
+        let map = DijkstraMap::new_empty(4, 1, 10.);
+
+        assert_eq!(map.map.len(), 4);
+        assert!(map.map.iter().all(|depth| *depth == f32::MAX));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut map = DijkstraMap::new_empty(4, 1, 10.);
+        map.map[1] = 1.;
+        map.map[3] = 3.;
+
+        DijkstraMap::clear(&mut map);
+
+        assert_eq!(map.map.len(), 4);
+        assert!(map.map.iter().all(|depth| *depth == f32::MAX));
+    }
+
+    #[test]
+    fn test_lowest_exit() {
+        let map = MiniMap {};
+        let exits_map = DijkstraMap::new(3, 1, &[0], &map, 10.);
+        let target = DijkstraMap::find_lowest_exit(&exits_map, 0, &map);
+        assert_eq!(target, Some(1));
+        let target = DijkstraMap::find_lowest_exit(&exits_map, 1, &map);
+        assert_eq!(target, Some(0));
+    }
+
     #[test]
     fn test_highest_exit() {
         let map = MiniMap {};


### PR DESCRIPTION
## What

Restore Dijkstra start tiles as seeded distance values and add regression coverage for the restored behavior.

## Why

`DijkstraMap.map` is public distance data, but the current build paths only write neighboring tiles during expansion. That leaves start tiles with a return-path cost instead of the expected seed distance, which can affect direct `map` reads and helper-based path selection.

This PR restores the intended seed behavior for `build`, `build_weighted`, and threaded `build_parallel`, then locks the behavior with tests for constructor output, weighted starts, empty maps, clearing, and lowest-exit selection.

Closes #26

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [x] I linked the related issue 

Threaded Dijkstra path was verified separately with `cargo test -p bracket-pathfinding --features threaded dijkstra::test -- --nocapture`

### Functional Validation

- [ ] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [ ] No sensitive values or credentials were introduced

### If Applicable

- [ ] Security impact considered (run `cargo audit` locally if needed)
- [ ] Breaking behavior changes are clearly described in this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pathfinding algorithm reliability through corrected initialization of distance calculations at starting positions, ensuring more accurate navigation results in pathfinding operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/roguekit/pull/100?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->