### PR TITLE
Fix:re-export XpFile, XpLayer, XpCell

### DIFF
--- a/bracket-terminal/src/lib.rs
+++ b/bracket-terminal/src/lib.rs
@@ -66,3 +66,18 @@ macro_rules! add_wasm_support {
         }
     };
 }
+
+#[cfg(test)]
+mod tests {
+    use super::prelude::{XpCell, XpFile, XpLayer};
+
+    fn takes_xp_cell(_: XpCell) {}
+
+    #[test]
+    fn prelude_reexports_rexpaint_types() {
+        let file = XpFile::new(1, 1);
+        let _layer: XpLayer = XpLayer::new(1, 1);
+        let cell: XpCell = file.layers[0].cells[0];
+        takes_xp_cell(cell);
+    }
+}

--- a/bracket-terminal/src/rex.rs
+++ b/bracket-terminal/src/rex.rs
@@ -1,7 +1,7 @@
 use crate::prelude::{Console, DrawBatch, FontCharType};
 use bracket_color::prelude::{ColorPair, RGBA};
 use bracket_geometry::prelude::Point;
-use bracket_rex::prelude::XpFile;
+pub use bracket_rex::prelude::{XpCell, XpFile, XpLayer};
 
 /// Applies an XpFile to a given console, with 0,0 offset by offset_x and offset-y.
 pub fn xp_to_console(


### PR DESCRIPTION
## What
Re-exports XpFile, XpLayer, and XpCell from bracket-terminal::rex, restoring their availability through the existing bracket-lib and rltk facade chain.

## Why
rltk examples already rely on these RexPaint types being reachable through the facade path. Restoring the bracket-terminal::rex export point matches that existing structure while avoiding a broader bracket-rex prelude re-export that could introduce conflicts such as XpColor.

No related issue.

## Checklist

### Required

- [x] `cargo check --all` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings -A clippy::multiple-crate-versions` passes
- [x] `cargo test --all` passes
- [ ] I linked the related issue (for example: `Closes #123`)

### Functional Validation

- [x] Behavior related to this change was verified locally (if applicable)
- [ ] Rendering/backend behavior was verified when runtime code changed (if applicable)
- [ ] Algorithm behavior (pathfinding/FOV/noise/random) was verified when affected (if applicable)
- [x] I added or updated tests for changed behavior (if applicable)

### Configuration & Docs

- [ ] User-facing docs were updated (`README.md`, `ARCHITECTURE.md`, or relevant manual pages, if applicable)
- [ ] New dependencies/configuration are documented (if applicable)
- [x] No sensitive values or credentials were introduced

### If Applicable

- [x] Security impact considered (run `cargo audit` locally if needed)
- [x] Breaking behavior changes are clearly described in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the public API to expose additional rexpaint-related types, enabling broader access to rexpaint file handling and manipulation.
* **Tests**
  * Added unit tests to verify the public prelude correctly exposes the rexpaint-related types and that those types integrate as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/utilForever/roguekit/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->